### PR TITLE
Wasm integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,8 @@ repository = "https://github.com/elementh/random_color.git"
 homepage ="https://github.com/elementh/random_color"
 description = "Rust crate for generating random attractive colors"
 
+[features]
+wasm-bindgen = ["rand/wasm-bindgen"]
+
 [dependencies]
 rand = { version = "0.7.3", features = ["small_rng"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "random_color"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Lucas Maximiliano Marino <lucasmmarino@gmail.com>"]
 license = "MIT"
 readme = "README.md"


### PR DESCRIPTION
Hey @elementh :wave: 

I've added a feature flag to be passed to `rand` to make the crate work on wasm targets.

```toml
random_color = { version = "0.5.1", features = ["wasm-bindgen"] }
```