### PR TITLE
Add wasm support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,14 @@ description = "Rust crate for generating random attractive colors"
 rgb_support = ["dep:rgb"]
 palette_support = ["dep:palette"]
 ecolor_support = ["dep:ecolor"]
+wasm = ["dep:getrandom"]
 
 [dependencies]
-rand = { version = "0.9", default-features=false, features = ["small_rng", "std", "std_rng"] }
+rand = { version = "0.9", features = ["small_rng"] }
 rgb = { version = "0.8.50", optional = true }
 palette = { version = "0.7.6", optional = true }
 ecolor = { version = "0.31", optional = true }
+getrandom = { version="0.3.4", optional = true, features = ["wasm_js"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ rand = { version = "0.9", features = ["small_rng"] }
 rgb = { version = "0.8.50", optional = true }
 palette = { version = "0.7.6", optional = true }
 ecolor = { version = "0.31", optional = true }
-getrandom = { version="0.3.4", optional = true, features = ["wasm_js"] }
+getrandom = { version = "0.3.4", optional = true, features = ["wasm_js"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ palette_support = ["dep:palette"]
 ecolor_support = ["dep:ecolor"]
 
 [dependencies]
-rand = { version = "0.9", default-features=false, features = ["small_rng", "std", "std_rng", "thread_rng"] }
+rand = { version = "0.9", default-features=false, features = ["small_rng", "std", "std_rng"] }
 rgb = { version = "0.8.50", optional = true }
 palette = { version = "0.7.6", optional = true }
 ecolor = { version = "0.31", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "random_color"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2021"
 authors = ["Lucas Maximiliano Marino <lucasmmarino@gmail.com>"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ palette_support = ["dep:palette"]
 ecolor_support = ["dep:ecolor"]
 
 [dependencies]
-rand = { version = "0.9", features = ["small_rng"] }
+rand = { version = "0.9", default-features=false, features = ["small_rng", "std", "std_rng", "thread_rng"] }
 rgb = { version = "0.8.50", optional = true }
 palette = { version = "0.7.6", optional = true }
 ecolor = { version = "0.31", optional = true }


### PR DESCRIPTION
Currently random_color doesnt support wasm because it relies on Rand which relies on getrandom which has a wasm feature that is disabled by default.

This PR adds a wasm feature to this crate that enables the wasm feature in getrandom.

Works in my project.